### PR TITLE
Potential fix for code scanning alert no. 66: Code injection

### DIFF
--- a/app/controllers/admin/site_settings_controller.rb
+++ b/app/controllers/admin/site_settings_controller.rb
@@ -67,6 +67,10 @@ class Admin::SiteSettingsController < Admin::AdminController
     params.require(:site_setting_id)
     id = params[:site_setting_id]
     raise Discourse::NotFound unless id.start_with?("default_")
+
+    allowed_methods = SiteSetting.public_methods(false).map(&:to_s)
+    raise Discourse::InvalidParameters, "Invalid site setting ID" unless allowed_methods.include?(id)
+
     new_value = value_or_default(params[id])
 
     raise_access_hidden_setting(id)


### PR DESCRIPTION
Potential fix for [https://github.com/pwnlaboratory/discourse/security/code-scanning/66](https://github.com/pwnlaboratory/discourse/security/code-scanning/66)

To fix the problem, we need to ensure that the `id` parameter is properly validated and sanitized before being used in the `public_send` method. One way to achieve this is by using a whitelist of allowed method names that can be invoked. This approach ensures that only safe and expected methods are called, preventing arbitrary code execution.

1. Create a whitelist of allowed method names.
2. Check if the `id` parameter is in the whitelist before using it in the `public_send` method.
3. Raise an error if the `id` parameter is not in the whitelist.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
